### PR TITLE
fix for images 2561px tall

### DIFF
--- a/src/ZoomifyGD.php
+++ b/src/ZoomifyGD.php
@@ -192,7 +192,7 @@ class ZoomifyGD extends Zoomify
         }
 
         // Create tiles for the current image row.
-        if ($imageRow) {
+        if ($imageRow && $row < $rowsForTier) {
             // Cycle through columns, then rows.
             $column = 0;
             $imageWidth = imagesx($imageRow);


### PR DESCRIPTION
Hello, I'm having an issue with an image exactly 2561px tall, and this fixes it.

To be more specific, with my image:
- Tier 4 has 11 rows
- Tier 3 has 5 rows
- and so on.

This means that:
- when doing 10th row of tier 4, the 5th row of tier 3 is created, as well as 3rd row of tier 2, and so on to 1st row of tier 0.
- when doing the 11th row of tier 4, a new unnecessary 6th row in tier 3 is created, and this also re-triggers 3rd row of tier 2 and so on to tier 0. Given that those had already been done, the temporary files needed are not there anymore, and those rows become black bars.